### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,194 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.1.0] - 2025-12-03
+
+### 🚀 Features
+
+- Implement ELN archive builder with egui GUI
+- Add date picker and validate timestamps
+- Show image thumbnails in attachments
+- Add theme toggle and image thumbnails
+- Add svg thumbnails
+- Add markdown preview and html export
+- Add simple markdown edit/preview controls
+- Add heading dropdown to markdown editor
+- Enrich RO-Crate metadata with genre and keywords
+- Improve keyword editor layout
+- Improve markdown editor and add side attachments pane
+- Show attachment metadata and move panel inline
+- Make markdown editor vertically resizable with full-width layout
+- Improve filename sanitization and hash verification
+- Table support in editor
+- Add table size picker
+- Support math expressions
+- Reject duplicate attachment names
+- Add export format selection for main text
+- Add elabftw extra fields import scaffold
+- Enhance extra fields validation and UI
+- Allow renaming imported metadata groups
+- Make metadata select fields toggleable
+- Add RemoveField message handler to extra fields
+- Inline edit metadata field titles and descriptions
+- Edit metadata fields via modal
+- Add delete control for imported metadata fields
+- Allow removing metadata groups and unassign fields
+- Add metadata fields via existing modal
+- Allow to edit group assignment of fields
+- Allow changing field group in modal with default fallback
+- Show empty metadata groups and support add-group/add-field flow
+- Add fields from group context and default section
+- Auto-create default group when adding first metadata field
+- *(ui)* Hide empty default section; only show when ungrouped fields exist
+- Allow choosing field type when creating extra fields
+- *(ui)* Prevent deleting the last extra-field group
+- *(ui)* Make extra-field groups collapsible
+- Enforce unique extra-field names with inline warning
+- Block save on empty required extra fields and highlight them
+- Disable save until required extra fields are filled
+- Highlight empty required extra fields and block save
+- Remove redundant required-fields modal
+- Validate url extra fields
+- Validate numeric extra field types
+- Block saving when fields are invalid
+- Add read-only support to extra fields
+- Add Windows 7 release target ([#11](https://github.com/Athemis/ELNPack/pull/11))
+
+### 🐛 Bug Fixes
+
+- Sanitize html and filenames
+- Tighten archive name sanitization
+- *(datetime)* Align default picker with local time and clarify ui
+- *(editor)* Fix styling of text selections
+- Keep file extensions; improve filename sanitation
+- Always reassign fields to a Default group when removing groups
+- Reuse existing group when adding fields and simplify group picker
+- Align elabftw export for importer compatibility
+- Document eln format version constant
+- Validate email extra fields
+- Respect extra field readonly in editor and selectors
+- Reset modal edit state on import
+- Handle empty file selection in attachments update function ([#9](https://github.com/Athemis/ELNPack/pull/9))
+
+### 🚜 Refactor
+
+- Extract markdown editor component
+- Unify markdown style application helpers
+- Simplify attachments panel layout
+- Simplify attachments and fix all clippy warnings
+- *(ui)* Extract keywords and datetime picker components
+- Align project layout with MVU structure
+- Extract shared validation logic for git hooks
+- *(ui)* Reuse a shared toggle switch and separate multi-select control
+- *(ui)* Streamline metadata field layout and unit handling
+- *(ui)* Refactor group header rendering with improved layout
+- Centralize extra field validation for ui and save paths
+- Deduplicate extra field trimming helpers
+- Centralize extra field group helpers
+- Reuse draft application for extra field creation/edit
+- Extract extra field view helpers
+- Clarify lowest_position_group_id naming.
+- Simplify name_conflict comparison
+- Simplify extra field value serialization
+- Simplify group renaming logic
+
+### 📚 Documentation
+
+- Update contributor guidelines
+- Update AGENTS for editor module
+- Refresh naming and licensing
+- Add rustdoc to ui components
+- Document REUSE usage and add MIT license file
+- Refine README and update project guidelines
+- Add rustdoc comments to core models and UI components
+- Update README.md
+- Update git hooks documentation in README and install script
+- Add MVU layering guidance to AGENTS.md
+- Clarify ExtraField value conversion
+- Improve inline code documentation ([#10](https://github.com/Athemis/ELNPack/pull/10))
+- Update contributing guide and README
+- Add Windows prerequisites section to README with VC++ info
+
+### 🎨 Styling
+
+- Use icon for attachment removal button
+- Use phosphor icons for confirmations
+- Use phosphor icons for heading selection
+- Drop RichText for icon display
+- Add icon to save button
+- *(ui)* Modify extra fields metadata import UI labels
+- Add missing newlines at end of files
+- Fix clippy warnings
+- Rename test to clarify group display name fallback behavior
+
+### 🧪 Testing
+
+- Add coverage for archive helpers and attachment thumbnails
+- Improve math syntax checks
+- Add tests for field/group edits
+- Add helpers for extra field fixtures
+- Clarify group removal coverage for extra fields
+- Remove redundant field removal test
+
+### ⚙️ Miscellaneous Tasks
+
+- Streamline image dependencies
+- Use egui dark/light mode switch
+- Place theme switch in top toolbar
+- Simplify theme switch toolbar
+- Streamline heading picker
+- Tidy heading dropdown placement
+- Restyle date/time inputs
+- Update egui stack and toolbar icons
+- Update AGENTS.md
+- Update AGENTS.md
+- Rename LICENSE.md to LICENSE
+- Update copyright statement in LICENSE
+- *(license)* Add SPDX headers and fix copyright holder
+- Update README
+- Add CI workflow and GitHub project templates
+- Add initial Dependabot configuration
+- Pin rust toolchain to stable
+- Add dependabot GitHub Actions updates
+- Fix clippy warnings
+- Fix code formatting
+- Add distributable git hooks and install script
+- Add read permission in CI workflow
+- Add missing SPDX license headers
+- Fix format of SPDX headers
+- Reformat SPDX header in README.md
+- Add REUSE dep5 file
+- Update SPDX headers
+- Migrate from dep5 to REUSE.toml
+- Ignore REUSE checks in AGENTS.md
+- Add CI and CodeQL badges to README.md
+- Reinstate SPDX headers in issue templates
+- Update format check in pre-commit hook
+- Update pre-commit-hook
+- Add static release pipeline
+- Add manual trigger to release pipeline
+- Cache cargo deps in release checks
+- Keep other release builds running on failure
+- Fix release build target expansion on windows
+- Cache cargo artifacts in CI workflow
+- Use dtolnay/rust-toolchain in workflows
+- Bump checkout action version
+- Pin rust-toolchan action version
+- Add math library linking for musl target
+- Add musl linker configuration
+- Add strip binary step for Linux builds
+- Remove musl Linux build
+- Release profile optimizations
+- Add pre-push hook to validate conventional commit messages
+- Simplify metadata field UI and move allow-multi to modal
+- Remove unnecessary v5 uuid feature
+- Add comment explaining group name rename logic
+- Cover configs/docs via REUSE annotations
+- Clean SPDX headers for configs/docs covered by REUSE.toml
+- Refactor release pipeline ([#12](https://github.com/Athemis/ELNPack/pull/12))
+- Use stable rust toolchain in workflow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.47"
+version = "1.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1201,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "endi"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "enum-map"
@@ -1978,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2016,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libloading"
@@ -2049,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+checksum = "8b484ba8d4f775eeca644c452a56650e544bf7e617f1d170fe7298122ead5222"
 dependencies = [
  "zlib-rs",
 ]
@@ -2091,9 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mac"
@@ -2217,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbdd3d7436f8b5e892b8b7ea114271ff0fa00bc5acae845d53b07d498616ef6"
+checksum = "80986bbbcf925ebd3be54c26613d861255284584501595cf418320c078945608"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -2960,9 +2960,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pxfm"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3cbdf373972bf78df4d3b518d07003938e2c7d1fb5891e55f9cb6df57009d84"
+checksum = "b3502d6155304a4173a5f2c34b52b7ed0dd085890326cb50fd625fdf39e86b3b"
 dependencies = [
  "num-traits",
 ]
@@ -3724,9 +3724,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -3736,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3747,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
 ]
@@ -3908,13 +3908,13 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom",
  "js-sys",
- "serde",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -3945,9 +3945,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3958,9 +3958,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3971,9 +3971,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3981,9 +3981,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3994,9 +3994,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
@@ -4138,9 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4869,9 +4869,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -5016,9 +5016,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e96e38ded30eeab90b6ba88cb888d70aef4e7489b6cd212c5e5b5ec38045b6"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
 dependencies = [
  "zbus_xml",
  "zvariant",
@@ -5026,9 +5026,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep-macros"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6821851fa840b708b4cbbaf6241868cabc85a2dc22f426361b0292bfc0b836"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5080,18 +5080,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.28"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.28"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5168,9 +5168,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+checksum = "36134c44663532e6519d7a6dfdbbe06f6f8192bde8ae9ed076e9b213f0e31df7"
 
 [[package]]
 name = "zopfli"


### PR DESCRIPTION


## 🤖 New release

* `elnpack`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0] - 2025-12-03

### 🚀 Features

- Import and export of eLabFTW-compatible metadata (extra fields)
- Attachment of files with preview for images
- Collision detection of filenames and file hashes
- Markdown editor for formatting main description text
- Export of eLabFTW-compatible ELN-Archives

</blockquote>
</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).