### PR TITLE
refactor: move thumbnail textures into ui state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,8 @@ target/
 Thumbs.db
 ehthumbs.db
 
+# Local git worktrees
+.worktrees/
+
 # SSH Keys
 id_ed25519*

--- a/src/mvu/mod.rs
+++ b/src/mvu/mod.rs
@@ -58,11 +58,8 @@ pub enum Msg {
     HelpOpened(Result<(), String>),
     ThumbnailDecoded {
         path: PathBuf,
+        request_id: u64,
         image: eframe::egui::ColorImage,
-    },
-    ThumbnailReady {
-        path: PathBuf,
-        texture: eframe::egui::TextureHandle,
     },
     DismissError,
     Markdown(MarkdownMsg),
@@ -76,7 +73,11 @@ pub enum Msg {
 pub enum Command {
     PickFiles,
     HashFile { path: PathBuf, _retry: bool },
-    LoadThumbnail { path: PathBuf, _retry: bool },
+    LoadThumbnail {
+        path: PathBuf,
+        _retry: bool,
+        request_id: u64,
+    },
     PickExtraFieldsFile,
     OpenUrl { url: String },
     SaveArchive(SavePayload),
@@ -150,41 +151,19 @@ pub fn update(model: &mut AppModel, msg: Msg, cmds: &mut Vec<Command>) {
                         cmds.push(Command::LoadThumbnail {
                             path,
                             _retry: false,
+                            request_id: 0,
                         })
                     }
                 }
             }
         }
-        Msg::ThumbnailDecoded { path, image } => {
-            // Actual texture creation must happen in ui.rs where ctx is available.
-            // Here we just store the decoded image in a temporary placeholder via AttachmentsMsg.
-            // This Msg variant should be transformed before reaching update; keeping a no-op to avoid panic.
-            let _ = (path, image);
-        }
-        Msg::ThumbnailReady { path, texture } => {
-            let mut att_cmds = Vec::new();
-            if let Some(event) = attachments::update(
-                &mut model.attachments,
-                AttachmentsMsg::ThumbnailReady { path, texture },
-                &mut att_cmds,
-            ) {
-                surface_event(model, event.message, event.is_error);
-            }
-            for c in att_cmds {
-                match c {
-                    AttachmentsCommand::PickFiles => cmds.push(Command::PickFiles),
-                    AttachmentsCommand::HashFile { path } => cmds.push(Command::HashFile {
-                        path,
-                        _retry: false,
-                    }),
-                    AttachmentsCommand::LoadThumbnail { path } => {
-                        cmds.push(Command::LoadThumbnail {
-                            path,
-                            _retry: false,
-                        })
-                    }
-                }
-            }
+        Msg::ThumbnailDecoded {
+            path,
+            request_id,
+            image,
+        } => {
+            // Texture realization is staged in the UI runtime where an egui context exists.
+            let _ = (path, request_id, image);
         }
         Msg::Keywords(m) => {
             if let Some(event) = keywords::update(&mut model.keywords, m) {
@@ -295,10 +274,18 @@ pub fn run_command(cmd: Command) -> Msg {
                 mime,
             })
         }
-        Command::LoadThumbnail { path, _retry: _ } => {
+        Command::LoadThumbnail {
+            path,
+            _retry: _,
+            request_id,
+        } => {
             match attachments::load_image_thumbnail(&path) {
-                Ok(image) => Msg::ThumbnailDecoded { path, image },
-                Err(_) => Msg::Attachments(AttachmentsMsg::ThumbnailFailed { path }),
+                Ok(image) => Msg::ThumbnailDecoded {
+                    path,
+                    request_id,
+                    image,
+                },
+                Err(_) => Msg::Attachments(AttachmentsMsg::ThumbnailFailed { path, request_id }),
             }
         }
         Command::SaveArchive(payload) => {
@@ -463,7 +450,11 @@ mod tests {
 
         assert_eq!(cmds.len(), 1);
         match cmds.pop().unwrap() {
-            Command::LoadThumbnail { path: p, _retry } => {
+            Command::LoadThumbnail {
+                path: p,
+                _retry,
+                request_id: _,
+            } => {
                 assert_eq!(p, path);
             }
             _ => panic!("unexpected command"),
@@ -492,12 +483,51 @@ mod tests {
         let mut cmds2 = Vec::new();
         update(
             &mut model,
-            Msg::Attachments(AttachmentsMsg::ThumbnailFailed { path }),
+            Msg::Attachments(AttachmentsMsg::ThumbnailFailed {
+                path,
+                request_id: 1,
+            }),
             &mut cmds2,
         );
         model.pending_commands = model.pending_commands.saturating_sub(1);
 
         assert_eq!(model.pending_commands, 0);
+    }
+
+    #[test]
+    fn thumbnail_failure_still_routes_through_attachment_messages() {
+        let msg = run_command(Command::LoadThumbnail {
+            path: PathBuf::from("missing.png"),
+            _retry: false,
+            request_id: 1,
+        });
+
+        assert!(matches!(
+            msg,
+            Msg::Attachments(AttachmentsMsg::ThumbnailFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn thumbnail_available_message_clears_loading_state() {
+        let mut model = AppModel::default();
+        let path = PathBuf::from("image.png");
+        let mut cmds = Vec::new();
+
+        update(
+            &mut model,
+            Msg::Attachments(AttachmentsMsg::LoadThumbnail(path.clone())),
+            &mut cmds,
+        );
+        assert!(model.attachments.is_thumbnail_loading(&path));
+
+        update(
+            &mut model,
+            Msg::Attachments(AttachmentsMsg::ThumbnailAvailable { path: path.clone() }),
+            &mut Vec::new(),
+        );
+
+        assert!(!model.attachments.is_thumbnail_loading(&path));
     }
 
     #[test]

--- a/src/mvu/mod.rs
+++ b/src/mvu/mod.rs
@@ -56,6 +56,10 @@ pub enum Msg {
     SaveCompleted(Result<PathBuf, String>),
     OpenHelp,
     HelpOpened(Result<(), String>),
+    /// Decoded thumbnail image staged for UI-side texture realization.
+    ///
+    /// `ElnPackApp::realize_pending_thumbnail_textures` consumes this runtime message
+    /// before it should ever reach `mvu::update`.
     ThumbnailDecoded {
         path: PathBuf,
         request_id: u64,
@@ -72,14 +76,19 @@ pub enum Msg {
 /// Commands represent side-effects executed between frames.
 pub enum Command {
     PickFiles,
-    HashFile { path: PathBuf, _retry: bool },
+    HashFile {
+        path: PathBuf,
+        _retry: bool,
+    },
     LoadThumbnail {
         path: PathBuf,
         _retry: bool,
         request_id: u64,
     },
     PickExtraFieldsFile,
-    OpenUrl { url: String },
+    OpenUrl {
+        url: String,
+    },
     SaveArchive(SavePayload),
 }
 
@@ -162,7 +171,8 @@ pub fn update(model: &mut AppModel, msg: Msg, cmds: &mut Vec<Command>) {
             request_id,
             image,
         } => {
-            // Texture realization is staged in the UI runtime where an egui context exists.
+            // Invariant: the UI runtime stages and realizes decoded thumbnails before
+            // this message should reach `mvu::update`; keep this arm as a no-op.
             let _ = (path, request_id, image);
         }
         Msg::Keywords(m) => {
@@ -278,16 +288,14 @@ pub fn run_command(cmd: Command) -> Msg {
             path,
             _retry: _,
             request_id,
-        } => {
-            match attachments::load_image_thumbnail(&path) {
-                Ok(image) => Msg::ThumbnailDecoded {
-                    path,
-                    request_id,
-                    image,
-                },
-                Err(_) => Msg::Attachments(AttachmentsMsg::ThumbnailFailed { path, request_id }),
-            }
-        }
+        } => match attachments::load_image_thumbnail(&path) {
+            Ok(image) => Msg::ThumbnailDecoded {
+                path,
+                request_id,
+                image,
+            },
+            Err(_) => Msg::Attachments(AttachmentsMsg::ThumbnailFailed { path, request_id }),
+        },
         Command::SaveArchive(payload) => {
             let res = build_and_write_archive(
                 &payload.output,

--- a/src/mvu/mod.rs
+++ b/src/mvu/mod.rs
@@ -65,6 +65,15 @@ pub enum Msg {
         request_id: u64,
         image: eframe::egui::ColorImage,
     },
+    /// Thumbnail load failure staged for UI-side request validation.
+    ///
+    /// `ElnPackApp::process_runtime_messages` validates the `request_id` against the
+    /// active shell-side request map before forwarding a simplified
+    /// [`AttachmentsMsg::ThumbnailFailed`] to `mvu::update`.
+    ThumbnailFailed {
+        path: PathBuf,
+        request_id: u64,
+    },
     DismissError,
     Markdown(MarkdownMsg),
     Attachments(AttachmentsMsg),
@@ -174,6 +183,11 @@ pub fn update(model: &mut AppModel, msg: Msg, cmds: &mut Vec<Command>) {
             // Invariant: the UI runtime stages and realizes decoded thumbnails before
             // this message should reach `mvu::update`; keep this arm as a no-op.
             let _ = (path, request_id, image);
+        }
+        Msg::ThumbnailFailed { path, request_id } => {
+            // Invariant: the UI runtime validates thumbnail failure request IDs and
+            // forwards only `AttachmentsMsg::ThumbnailFailed { path }`.
+            let _ = (path, request_id);
         }
         Msg::Keywords(m) => {
             if let Some(event) = keywords::update(&mut model.keywords, m) {
@@ -294,7 +308,7 @@ pub fn run_command(cmd: Command) -> Msg {
                 request_id,
                 image,
             },
-            Err(_) => Msg::Attachments(AttachmentsMsg::ThumbnailFailed { path, request_id }),
+            Err(_) => Msg::ThumbnailFailed { path, request_id },
         },
         Command::SaveArchive(payload) => {
             let res = build_and_write_archive(
@@ -491,10 +505,7 @@ mod tests {
         let mut cmds2 = Vec::new();
         update(
             &mut model,
-            Msg::Attachments(AttachmentsMsg::ThumbnailFailed {
-                path,
-                request_id: 1,
-            }),
+            Msg::Attachments(AttachmentsMsg::ThumbnailFailed { path }),
             &mut cmds2,
         );
         model.pending_commands = model.pending_commands.saturating_sub(1);
@@ -510,10 +521,7 @@ mod tests {
             request_id: 1,
         });
 
-        assert!(matches!(
-            msg,
-            Msg::Attachments(AttachmentsMsg::ThumbnailFailed { .. })
-        ));
+        assert!(matches!(msg, Msg::ThumbnailFailed { .. }));
     }
 
     #[test]

--- a/src/ui/components/attachments.rs
+++ b/src/ui/components/attachments.rs
@@ -40,11 +40,10 @@ impl AttachmentItem {
     }
 }
 
-/// MVU state for the attachments picker and thumbnail cache.
+/// MVU state for the attachments picker and thumbnail loading status.
 #[derive(Default)]
 pub struct AttachmentsModel {
     attachments: Vec<AttachmentItem>,
-    thumbnail_cache: HashMap<PathBuf, egui::TextureHandle>,
     thumbnail_failures: HashSet<PathBuf>,
     thumbnail_loading: HashSet<PathBuf>,
     hashes: HashSet<String>,
@@ -53,7 +52,6 @@ pub struct AttachmentsModel {
 }
 
 /// Messages emitted by the attachments view.
-// Debug omitted because TextureHandle is not Debug.
 pub enum AttachmentsMsg {
     RequestPickFiles,
     FilesPicked(Vec<PathBuf>),
@@ -64,12 +62,10 @@ pub enum AttachmentsMsg {
         size: u64,
         mime: String,
     },
-    ThumbnailReady {
-        path: PathBuf,
-        texture: egui::TextureHandle,
-    },
+    ThumbnailAvailable { path: PathBuf },
     ThumbnailFailed {
         path: PathBuf,
+        request_id: u64,
     },
     Remove(usize),
     StartEdit(usize),
@@ -108,6 +104,12 @@ impl AttachmentsModel {
         let size = path.metadata().map(|m| m.len()).unwrap_or(0);
         let mime = guess_mime(&path);
         add_attachment_with_meta(self, path, sha256, size, mime)
+    }
+
+    /// Convenience helper for tests to inspect thumbnail loading state.
+    #[cfg(test)]
+    pub fn is_thumbnail_loading(&self, path: &Path) -> bool {
+        self.thumbnail_loading.contains(path)
     }
 }
 
@@ -157,12 +159,12 @@ pub fn update(
                 is_error: !added,
             })
         }
-        AttachmentsMsg::ThumbnailReady { path, texture } => {
-            model.thumbnail_cache.insert(path.clone(), texture);
+        AttachmentsMsg::ThumbnailAvailable { path } => {
+            model.thumbnail_failures.remove(&path);
             model.thumbnail_loading.remove(&path);
             None
         }
-        AttachmentsMsg::ThumbnailFailed { path } => {
+        AttachmentsMsg::ThumbnailFailed { path, request_id: _ } => {
             model.thumbnail_failures.insert(path.clone());
             model.thumbnail_loading.remove(&path);
             None
@@ -197,7 +199,11 @@ pub fn update(
 }
 
 /// Render the attachments panel and return any messages triggered by user interaction.
-pub fn view(ui: &mut egui::Ui, model: &AttachmentsModel) -> Vec<AttachmentsMsg> {
+pub fn view(
+    ui: &mut egui::Ui,
+    model: &AttachmentsModel,
+    textures: &HashMap<PathBuf, egui::TextureHandle>,
+) -> Vec<AttachmentsMsg> {
     let mut msgs = Vec::new();
 
     let add_resp = ui.add(egui::Button::new(format!(
@@ -222,7 +228,7 @@ pub fn view(ui: &mut egui::Ui, model: &AttachmentsModel) -> Vec<AttachmentsMsg> 
                     egui::RichText::new("No attachments").color(egui::Color32::from_gray(150)),
                 );
             } else {
-                render_attachment_list(ui, model, &mut msgs);
+                render_attachment_list(ui, model, textures, &mut msgs);
             }
         });
 
@@ -233,6 +239,7 @@ pub fn view(ui: &mut egui::Ui, model: &AttachmentsModel) -> Vec<AttachmentsMsg> 
 fn render_attachment_list(
     ui: &mut egui::Ui,
     model: &AttachmentsModel,
+    textures: &HashMap<PathBuf, egui::TextureHandle>,
     msgs: &mut Vec<AttachmentsMsg>,
 ) {
     for index in 0..model.attachments.len() {
@@ -256,7 +263,7 @@ fn render_attachment_list(
         ui.horizontal(|ui| {
             let icon_for_mime = icon_for(&mime, &path);
 
-            let _thumb_slot = if let Some(texture) = model.thumbnail_cache.get(&path) {
+            let _thumb_slot = if let Some(texture) = textures.get(&path) {
                 let size = texture.size_vec2();
                 let max = 96.0;
                 let scale = (max / size.x).min(max / size.y).min(1.0);
@@ -427,11 +434,11 @@ fn add_attachment_with_meta(
     true
 }
 
-/// Remove an attachment and associated cache entries safely.
+/// Remove an attachment and associated thumbnail state safely.
 fn remove_attachment(model: &mut AttachmentsModel, index: usize) {
     if let Some(removed) = model.attachments.get(index) {
-        model.thumbnail_cache.remove(&removed.path);
         model.thumbnail_failures.remove(&removed.path);
+        model.thumbnail_loading.remove(&removed.path);
         if removed.sha256 != "unavailable" {
             model.hashes.remove(&removed.sha256);
         }
@@ -574,14 +581,15 @@ pub(crate) fn load_image_thumbnail(path: &Path) -> Result<egui::ColorImage, Stri
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::fs;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use eframe::egui::Color32;
     use image::{ImageBuffer, Rgba};
     use tempfile::TempDir;
 
-    use super::{AttachmentsModel, is_image, load_image_thumbnail};
+    use super::{view, AttachmentsModel, AttachmentsMsg, is_image, load_image_thumbnail};
 
     // Ensures extension filtering matches documented formats and rejects others.
     #[test]
@@ -692,5 +700,115 @@ mod tests {
         assert_eq!(model.attachments[0].sanitized_name, "Cafe_draft.md");
         assert_eq!(model.attachments[1].sanitized_name, "file.with.dots.tar.gz");
         assert_eq!(model.attachments[2].sanitized_name, "normal-file_123.txt");
+    }
+
+    #[test]
+    fn thumbnail_available_clears_loading_without_storing_texture_state() {
+        let path = PathBuf::from("/tmp/example.png");
+        let mut model = AttachmentsModel::default();
+        let mut cmds = Vec::new();
+
+        super::update(
+            &mut model,
+            super::AttachmentsMsg::LoadThumbnail(path.clone()),
+            &mut cmds,
+        );
+        assert!(model.thumbnail_loading.contains(&path));
+
+        let event = super::update(
+            &mut model,
+            super::AttachmentsMsg::ThumbnailAvailable { path: path.clone() },
+            &mut Vec::new(),
+        );
+
+        assert!(event.is_none());
+        assert!(!model.thumbnail_loading.contains(&path));
+        assert!(!model.thumbnail_failures.contains(&path));
+    }
+
+    #[test]
+    fn remove_clears_thumbnail_loading_for_readded_path() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("example.png");
+        fs::write(&path, b"same-file").unwrap();
+
+        let mut model = AttachmentsModel::default();
+        assert!(model.add_path(path.clone()));
+
+        super::update(
+            &mut model,
+            super::AttachmentsMsg::LoadThumbnail(path.clone()),
+            &mut Vec::new(),
+        );
+        assert!(model.is_thumbnail_loading(&path));
+
+        super::update(&mut model, super::AttachmentsMsg::Remove(0), &mut Vec::new());
+        assert!(!model.is_thumbnail_loading(&path));
+
+        assert!(model.add_path(path.clone()));
+
+        let ctx = egui::Context::default();
+        let mut out = Vec::new();
+        let _ = ctx.run(Default::default(), |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                out = view(ui, &model, &HashMap::new());
+            });
+        });
+
+        assert!(
+            out.iter()
+                .any(|msg| matches!(msg, AttachmentsMsg::LoadThumbnail(p) if p == &path))
+        );
+    }
+
+    #[test]
+    fn view_requests_thumbnail_when_image_has_no_cached_texture() {
+        let mut model = AttachmentsModel::default();
+        let path = PathBuf::from("example.png");
+        assert!(model.add_path(path.clone()));
+
+        let ctx = egui::Context::default();
+        let mut out = Vec::new();
+
+        let _ = ctx.run(Default::default(), |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                out = view(ui, &model, &HashMap::new());
+            });
+        });
+
+        assert!(
+            out.iter()
+                .any(|msg| matches!(msg, AttachmentsMsg::LoadThumbnail(p) if p == &path))
+        );
+    }
+
+    #[test]
+    fn view_uses_external_texture_cache_for_image_thumbnails() {
+        let mut model = AttachmentsModel::default();
+        let path = PathBuf::from("example.png");
+        assert!(model.add_path(path.clone()));
+
+        let ctx = egui::Context::default();
+        let mut out = Vec::new();
+        let mut textures = HashMap::new();
+        textures.insert(
+            path.clone(),
+            ctx.load_texture(
+                "cached-thumbnail",
+                egui::ColorImage::from_rgba_unmultiplied([1, 1], &[255, 255, 255, 255]),
+                egui::TextureOptions::default(),
+            ),
+        );
+
+        let _ = ctx.run(Default::default(), |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                out = view(ui, &model, &textures);
+            });
+        });
+
+        assert!(
+            !out.iter()
+                .any(|msg| matches!(msg, AttachmentsMsg::LoadThumbnail(p) if p == &path))
+        );
     }
 }

--- a/src/ui/components/attachments.rs
+++ b/src/ui/components/attachments.rs
@@ -66,12 +66,8 @@ pub enum AttachmentsMsg {
         path: PathBuf,
     },
     /// Thumbnail load failed after runtime-shell request validation.
-    ///
-    /// `request_id` is informational for tracing; staleness is validated in the
-    /// UI runtime shell before this reducer sees the message.
     ThumbnailFailed {
         path: PathBuf,
-        request_id: u64,
     },
     Remove(usize),
     StartEdit(usize),
@@ -171,10 +167,7 @@ pub fn update(
             None
         }
         // Request validation happens in the UI runtime shell before this reducer runs.
-        AttachmentsMsg::ThumbnailFailed {
-            path,
-            request_id: _,
-        } => {
+        AttachmentsMsg::ThumbnailFailed { path } => {
             model.thumbnail_failures.insert(path.clone());
             model.thumbnail_loading.remove(&path);
             None

--- a/src/ui/components/attachments.rs
+++ b/src/ui/components/attachments.rs
@@ -761,8 +761,8 @@ mod tests {
 
         let ctx = egui::Context::default();
         let mut out = Vec::new();
-        let _ = ctx.run(Default::default(), |ctx| {
-            egui::CentralPanel::default().show(ctx, |ui| {
+        let _ = ctx.run_ui(Default::default(), |ui| {
+            egui::CentralPanel::default().show_inside(ui, |ui| {
                 out = view(ui, &model, &HashMap::new());
             });
         });
@@ -782,8 +782,8 @@ mod tests {
         let ctx = egui::Context::default();
         let mut out = Vec::new();
 
-        let _ = ctx.run(Default::default(), |ctx| {
-            egui::CentralPanel::default().show(ctx, |ui| {
+        let _ = ctx.run_ui(Default::default(), |ui| {
+            egui::CentralPanel::default().show_inside(ui, |ui| {
                 out = view(ui, &model, &HashMap::new());
             });
         });
@@ -812,8 +812,8 @@ mod tests {
             ),
         );
 
-        let _ = ctx.run(Default::default(), |ctx| {
-            egui::CentralPanel::default().show(ctx, |ui| {
+        let _ = ctx.run_ui(Default::default(), |ui| {
+            egui::CentralPanel::default().show_inside(ui, |ui| {
                 out = view(ui, &model, &textures);
             });
         });

--- a/src/ui/components/attachments.rs
+++ b/src/ui/components/attachments.rs
@@ -62,7 +62,13 @@ pub enum AttachmentsMsg {
         size: u64,
         mime: String,
     },
-    ThumbnailAvailable { path: PathBuf },
+    ThumbnailAvailable {
+        path: PathBuf,
+    },
+    /// Thumbnail load failed after runtime-shell request validation.
+    ///
+    /// `request_id` is informational for tracing; staleness is validated in the
+    /// UI runtime shell before this reducer sees the message.
     ThumbnailFailed {
         path: PathBuf,
         request_id: u64,
@@ -164,7 +170,11 @@ pub fn update(
             model.thumbnail_loading.remove(&path);
             None
         }
-        AttachmentsMsg::ThumbnailFailed { path, request_id: _ } => {
+        // Request validation happens in the UI runtime shell before this reducer runs.
+        AttachmentsMsg::ThumbnailFailed {
+            path,
+            request_id: _,
+        } => {
             model.thumbnail_failures.insert(path.clone());
             model.thumbnail_loading.remove(&path);
             None
@@ -263,11 +273,11 @@ fn render_attachment_list(
         ui.horizontal(|ui| {
             let icon_for_mime = icon_for(&mime, &path);
 
-            let _thumb_slot = if let Some(texture) = textures.get(&path) {
+            if let Some(texture) = textures.get(&path) {
                 let size = texture.size_vec2();
                 let max = 96.0;
                 let scale = (max / size.x).min(max / size.y).min(1.0);
-                ui.add(egui::Image::new((texture.id(), size * scale))).rect
+                ui.add(egui::Image::new((texture.id(), size * scale)));
             } else {
                 let thumb_rect = ui.allocate_space(egui::vec2(96.0, 72.0)).1;
 
@@ -282,9 +292,7 @@ fn render_attachment_list(
                 } else {
                     render_placeholder_icon(ui, thumb_rect, icon_for_mime);
                 }
-
-                thumb_rect
-            };
+            }
 
             ui.vertical(|ui| {
                 ui.horizontal(|ui| {
@@ -589,7 +597,7 @@ mod tests {
     use image::{ImageBuffer, Rgba};
     use tempfile::TempDir;
 
-    use super::{view, AttachmentsModel, AttachmentsMsg, is_image, load_image_thumbnail};
+    use super::{AttachmentsModel, AttachmentsMsg, is_image, load_image_thumbnail, view};
 
     // Ensures extension filtering matches documented formats and rejects others.
     #[test]
@@ -742,7 +750,11 @@ mod tests {
         );
         assert!(model.is_thumbnail_loading(&path));
 
-        super::update(&mut model, super::AttachmentsMsg::Remove(0), &mut Vec::new());
+        super::update(
+            &mut model,
+            super::AttachmentsMsg::Remove(0),
+            &mut Vec::new(),
+        );
         assert!(!model.is_thumbnail_loading(&path));
 
         assert!(model.add_path(path.clone()));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -162,10 +162,7 @@ impl ElnPackApp {
                     self.pending_thumbnail_images
                         .push((path, request_id, image));
                 }
-                mvu::Msg::Attachments(attachments::AttachmentsMsg::ThumbnailFailed {
-                    path,
-                    request_id,
-                }) => {
+                mvu::Msg::ThumbnailFailed { path, request_id } => {
                     if self.active_thumbnail_requests.get(&path).copied() != Some(request_id) {
                         continue;
                     }
@@ -173,10 +170,7 @@ impl ElnPackApp {
                     let mut commands = Vec::new();
                     mvu::update(
                         &mut self.model,
-                        Msg::Attachments(attachments::AttachmentsMsg::ThumbnailFailed {
-                            path,
-                            request_id,
-                        }),
+                        Msg::Attachments(attachments::AttachmentsMsg::ThumbnailFailed { path }),
                         &mut commands,
                     );
                     self.dispatch_commands(commands);
@@ -201,16 +195,15 @@ impl ElnPackApp {
                     self.dispatch_commands(commands);
                 }
                 other => {
-                    if let Msg::Attachments(attachments::AttachmentsMsg::Remove(index)) = &other {
-                        if let Some(path) = self
+                    if let Msg::Attachments(attachments::AttachmentsMsg::Remove(index)) = &other
+                        && let Some(path) = self
                             .model
                             .attachments
                             .attachments()
                             .get(*index)
                             .map(|item| item.path.clone())
-                        {
-                            self.invalidate_thumbnail_runtime_state(path.as_path());
-                        }
+                    {
+                        self.invalidate_thumbnail_runtime_state(path.as_path());
                     }
                     let mut commands = Vec::new();
                     mvu::update(&mut self.model, other, &mut commands);
@@ -668,11 +661,10 @@ mod tests {
         assert_ne!(old_request_id, new_request_id);
         assert!(app.model.attachments.is_thumbnail_loading(&path));
 
-        app.inbox
-            .push(Msg::Attachments(AttachmentsMsg::ThumbnailFailed {
-                path: path.clone(),
-                request_id: old_request_id,
-            }));
+        app.inbox.push(Msg::ThumbnailFailed {
+            path: path.clone(),
+            request_id: old_request_id,
+        });
         app.process_runtime_messages();
 
         assert!(app.model.attachments.is_thumbnail_loading(&path));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,6 +6,9 @@
 
 pub mod components;
 
+use std::collections::HashMap;
+use std::path::PathBuf;
+
 use eframe::egui;
 
 use crate::logic::eln::{ArchiveGenre, ensure_extension, suggested_archive_name};
@@ -18,6 +21,10 @@ pub struct ElnPackApp {
     inbox: Vec<Msg>,
     cmd_tx: crossbeam_channel::Sender<Command>,
     msg_rx: crossbeam_channel::Receiver<Msg>,
+    thumbnail_textures: HashMap<PathBuf, egui::TextureHandle>,
+    pending_thumbnail_images: Vec<(PathBuf, u64, egui::ColorImage)>,
+    active_thumbnail_requests: HashMap<PathBuf, u64>,
+    next_thumbnail_request_id: u64,
 }
 
 impl Default for ElnPackApp {
@@ -48,6 +55,10 @@ impl Default for ElnPackApp {
             inbox: Vec::new(),
             cmd_tx,
             msg_rx,
+            thumbnail_textures: HashMap::new(),
+            pending_thumbnail_images: Vec::new(),
+            active_thumbnail_requests: HashMap::new(),
+            next_thumbnail_request_id: 1,
         }
     }
 }
@@ -57,7 +68,7 @@ impl eframe::App for ElnPackApp {
     ///
     /// This method:
     /// - Drains messages produced by background command workers and enqueues them for processing.
-    /// - Processes pending messages, converting decoded thumbnails into UI textures and applying MVU updates which may produce new commands sent to workers.
+    /// - Processes runtime messages and stages decoded thumbnail images for later UI realization.
     ///
     /// # Parameters
     ///
@@ -66,11 +77,14 @@ impl eframe::App for ElnPackApp {
     ///
     fn logic(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         self.ensure_spacing(ctx);
-        self.process_pending_messages(ctx);
+        self.process_runtime_messages();
     }
 
     /// Main application UI pass for the root viewport.
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        self.realize_pending_thumbnail_textures(ui.ctx());
+        self.process_runtime_messages();
+
         egui::Panel::top("top_bar").show_inside(ui, |ui| {
             ui.add_space(6.0);
             ui.horizontal(|ui| {
@@ -131,7 +145,7 @@ impl ElnPackApp {
         });
     }
 
-    fn process_pending_messages(&mut self, ctx: &egui::Context) {
+    fn process_runtime_messages(&mut self) {
         while let Ok(msg) = self.msg_rx.try_recv() {
             self.model.pending_commands = self.model.pending_commands.saturating_sub(1);
             self.inbox.push(msg);
@@ -140,26 +154,129 @@ impl ElnPackApp {
         let mut msgs = std::mem::take(&mut self.inbox);
         while let Some(msg) = msgs.pop() {
             match msg {
-                mvu::Msg::ThumbnailDecoded { path, image } => {
-                    let texture = ctx.load_texture(
-                        format!("thumb-{}", path.display()),
-                        image,
-                        egui::TextureOptions::default(),
+                mvu::Msg::ThumbnailDecoded {
+                    path,
+                    request_id,
+                    image,
+                } => {
+                    self.pending_thumbnail_images.push((path, request_id, image));
+                }
+                mvu::Msg::Attachments(attachments::AttachmentsMsg::ThumbnailFailed {
+                    path,
+                    request_id,
+                }) => {
+                    if self.active_thumbnail_requests.get(&path).copied() != Some(request_id) {
+                        continue;
+                    }
+
+                    let mut commands = Vec::new();
+                    mvu::update(
+                        &mut self.model,
+                        Msg::Attachments(attachments::AttachmentsMsg::ThumbnailFailed {
+                            path,
+                            request_id,
+                        }),
+                        &mut commands,
                     );
-                    msgs.push(mvu::Msg::ThumbnailReady { path, texture });
+                    self.dispatch_commands(commands);
                 }
                 other => {
-                    let mut commands = Vec::new();
-                    mvu::update(&mut self.model, other, &mut commands);
-                    for cmd in commands {
-                        if self.cmd_tx.send(cmd).is_ok() {
-                            self.model.pending_commands += 1;
+                    if let Msg::Attachments(attachments::AttachmentsMsg::Remove(index)) = &other {
+                        if let Some(path) = self
+                            .model
+                            .attachments
+                            .attachments()
+                            .get(*index)
+                            .map(|item| item.path.clone())
+                        {
+                            self.invalidate_thumbnail_runtime_state(&path);
                         }
                     }
+                    let mut commands = Vec::new();
+                    mvu::update(&mut self.model, other, &mut commands);
+                    self.dispatch_commands(commands);
                 }
             }
         }
         self.inbox = msgs;
+    }
+
+    fn realize_pending_thumbnail_textures(&mut self, ctx: &egui::Context) {
+        for (path, request_id, image) in std::mem::take(&mut self.pending_thumbnail_images) {
+            if !self
+                .model
+                .attachments
+                .attachments()
+                .iter()
+                .any(|item| item.path == path)
+            {
+                continue;
+            }
+
+            if self.active_thumbnail_requests.get(&path).copied() != Some(request_id) {
+                continue;
+            }
+
+            let texture = ctx.load_texture(
+                format!("thumb-{}", path.display()),
+                image,
+                egui::TextureOptions::default(),
+            );
+            self.thumbnail_textures.insert(path.clone(), texture);
+            self.inbox
+                .push(Msg::Attachments(attachments::AttachmentsMsg::ThumbnailAvailable {
+                    path,
+                }));
+        }
+    }
+
+    fn prune_thumbnail_textures(&mut self) {
+        let paths: std::collections::HashSet<PathBuf> = self
+            .model
+            .attachments
+            .attachments()
+            .iter()
+            .map(|item| item.path.clone())
+            .collect();
+        self.thumbnail_textures
+            .retain(|path, _| paths.contains(path));
+        self.active_thumbnail_requests
+            .retain(|path, _| paths.contains(path));
+        self.pending_thumbnail_images
+            .retain(|(path, _, _)| paths.contains(path));
+    }
+
+    fn invalidate_thumbnail_runtime_state(&mut self, path: &PathBuf) {
+        self.thumbnail_textures.remove(path);
+        self.active_thumbnail_requests.remove(path);
+        self.pending_thumbnail_images
+            .retain(|(pending_path, _, _)| pending_path != path);
+    }
+
+    fn dispatch_commands(&mut self, commands: Vec<Command>) {
+        for cmd in commands {
+            let cmd = match cmd {
+                Command::LoadThumbnail {
+                    path,
+                    _retry,
+                    request_id: _,
+                } => {
+                    let request_id = self.next_thumbnail_request_id;
+                    self.next_thumbnail_request_id += 1;
+                    self.active_thumbnail_requests.insert(path.clone(), request_id);
+                    Command::LoadThumbnail {
+                        path,
+                        _retry,
+                        request_id,
+                    }
+                }
+                other => other,
+            };
+
+            if self.cmd_tx.send(cmd).is_ok() {
+                self.model.pending_commands += 1;
+            }
+        }
     }
 
     /// Render the global theme preference control with a small vertical gap.
@@ -300,10 +417,12 @@ impl ElnPackApp {
 
     /// Render attachments as a collapsible section in the main column.
     fn render_attachments_section(&mut self, ui: &mut egui::Ui) {
+        self.prune_thumbnail_textures();
         egui::CollapsingHeader::new("Attachments")
             .default_open(true)
             .show(ui, |ui| {
-                let att_msgs = attachments::view(ui, &self.model.attachments);
+                let att_msgs =
+                    attachments::view(ui, &self.model.attachments, &self.thumbnail_textures);
                 self.inbox
                     .extend(att_msgs.into_iter().map(Msg::Attachments));
             });
@@ -373,5 +492,165 @@ impl ElnPackApp {
                 }
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::components::attachments::AttachmentsMsg;
+    use tempfile::TempDir;
+
+    fn sample_image() -> egui::ColorImage {
+        egui::ColorImage::from_rgba_unmultiplied([1, 1], &[255, 255, 255, 255])
+    }
+
+    #[test]
+    fn realizing_pending_thumbnail_textures_enqueues_thumbnail_available() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("thumb.png");
+        std::fs::write(&path, b"thumb-bytes").unwrap();
+
+        let mut app = ElnPackApp::default();
+        assert!(app.model.attachments.add_path(path.clone()));
+
+        let mut cmds = Vec::new();
+        mvu::update(
+            &mut app.model,
+            Msg::Attachments(AttachmentsMsg::LoadThumbnail(path.clone())),
+            &mut cmds,
+        );
+        assert!(app.model.attachments.is_thumbnail_loading(&path));
+        app.dispatch_commands(cmds);
+
+        let request_id = app.active_thumbnail_requests[&path];
+        app.pending_thumbnail_images
+            .push((path.clone(), request_id, sample_image()));
+
+        let ctx = egui::Context::default();
+        app.realize_pending_thumbnail_textures(&ctx);
+
+        assert!(app.thumbnail_textures.contains_key(&path));
+        assert!(matches!(
+            app.inbox.pop(),
+            Some(Msg::Attachments(AttachmentsMsg::ThumbnailAvailable { path: p })) if p == path
+        ));
+    }
+
+    #[test]
+    fn realizing_pending_thumbnail_textures_skips_removed_attachments() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("thumb.png");
+        std::fs::write(&path, b"thumb-bytes").unwrap();
+
+        let mut app = ElnPackApp::default();
+        assert!(app.model.attachments.add_path(path.clone()));
+        mvu::update(
+            &mut app.model,
+            Msg::Attachments(AttachmentsMsg::Remove(0)),
+            &mut Vec::new(),
+        );
+
+        app.pending_thumbnail_images.push((path.clone(), 1, sample_image()));
+
+        let ctx = egui::Context::default();
+        app.realize_pending_thumbnail_textures(&ctx);
+
+        assert!(!app.thumbnail_textures.contains_key(&path));
+        assert!(app.inbox.is_empty());
+    }
+
+    #[test]
+    fn stale_thumbnail_results_for_readded_paths_are_ignored() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("thumb.png");
+        std::fs::write(&path, b"thumb-bytes").unwrap();
+
+        let mut app = ElnPackApp::default();
+        assert!(app.model.attachments.add_path(path.clone()));
+
+        let mut cmds = Vec::new();
+        mvu::update(
+            &mut app.model,
+            Msg::Attachments(AttachmentsMsg::LoadThumbnail(path.clone())),
+            &mut cmds,
+        );
+        app.dispatch_commands(cmds);
+        let old_request_id = app.active_thumbnail_requests[&path];
+
+        mvu::update(
+            &mut app.model,
+            Msg::Attachments(AttachmentsMsg::Remove(0)),
+            &mut Vec::new(),
+        );
+        app.invalidate_thumbnail_runtime_state(&path);
+
+        assert!(app.model.attachments.add_path(path.clone()));
+        let mut cmds = Vec::new();
+        mvu::update(
+            &mut app.model,
+            Msg::Attachments(AttachmentsMsg::LoadThumbnail(path.clone())),
+            &mut cmds,
+        );
+        app.dispatch_commands(cmds);
+        let new_request_id = app.active_thumbnail_requests[&path];
+        assert_ne!(old_request_id, new_request_id);
+
+        app.pending_thumbnail_images
+            .push((path.clone(), old_request_id, sample_image()));
+
+        let ctx = egui::Context::default();
+        app.realize_pending_thumbnail_textures(&ctx);
+
+        assert!(!app.thumbnail_textures.contains_key(&path));
+        assert!(app.inbox.is_empty());
+    }
+
+    #[test]
+    fn stale_thumbnail_failures_for_readded_paths_are_ignored() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("thumb.png");
+        std::fs::write(&path, b"thumb-bytes").unwrap();
+
+        let mut app = ElnPackApp::default();
+        assert!(app.model.attachments.add_path(path.clone()));
+
+        let mut cmds = Vec::new();
+        mvu::update(
+            &mut app.model,
+            Msg::Attachments(AttachmentsMsg::LoadThumbnail(path.clone())),
+            &mut cmds,
+        );
+        app.dispatch_commands(cmds);
+        let old_request_id = app.active_thumbnail_requests[&path];
+
+        mvu::update(
+            &mut app.model,
+            Msg::Attachments(AttachmentsMsg::Remove(0)),
+            &mut Vec::new(),
+        );
+        app.invalidate_thumbnail_runtime_state(&path);
+
+        assert!(app.model.attachments.add_path(path.clone()));
+        let mut cmds = Vec::new();
+        mvu::update(
+            &mut app.model,
+            Msg::Attachments(AttachmentsMsg::LoadThumbnail(path.clone())),
+            &mut cmds,
+        );
+        app.dispatch_commands(cmds);
+        let new_request_id = app.active_thumbnail_requests[&path];
+        assert_ne!(old_request_id, new_request_id);
+        assert!(app.model.attachments.is_thumbnail_loading(&path));
+
+        app.inbox
+            .push(Msg::Attachments(AttachmentsMsg::ThumbnailFailed {
+                path: path.clone(),
+                request_id: old_request_id,
+            }));
+        app.process_runtime_messages();
+
+        assert!(app.model.attachments.is_thumbnail_loading(&path));
+        assert_eq!(app.active_thumbnail_requests.get(&path), Some(&new_request_id));
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -180,6 +180,25 @@ impl ElnPackApp {
                     );
                     self.dispatch_commands(commands);
                 }
+                Msg::Attachments(attachments::AttachmentsMsg::LoadThumbnail(path)) => {
+                    if !self
+                        .model
+                        .attachments
+                        .attachments()
+                        .iter()
+                        .any(|item| item.path == path)
+                    {
+                        continue;
+                    }
+
+                    let mut commands = Vec::new();
+                    mvu::update(
+                        &mut self.model,
+                        Msg::Attachments(attachments::AttachmentsMsg::LoadThumbnail(path)),
+                        &mut commands,
+                    );
+                    self.dispatch_commands(commands);
+                }
                 other => {
                     if let Msg::Attachments(attachments::AttachmentsMsg::Remove(index)) = &other {
                         if let Some(path) = self
@@ -652,5 +671,26 @@ mod tests {
 
         assert!(app.model.attachments.is_thumbnail_loading(&path));
         assert_eq!(app.active_thumbnail_requests.get(&path), Some(&new_request_id));
+    }
+
+    #[test]
+    fn removing_attachment_discards_queued_thumbnail_loads() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("thumb.png");
+        std::fs::write(&path, b"thumb-bytes").unwrap();
+
+        let mut app = ElnPackApp::default();
+        assert!(app.model.attachments.add_path(path.clone()));
+
+        app.inbox.push(Msg::Attachments(AttachmentsMsg::LoadThumbnail(
+            path.clone(),
+        )));
+        app.inbox.push(Msg::Attachments(AttachmentsMsg::Remove(0)));
+
+        app.process_runtime_messages();
+
+        assert!(!app.model.attachments.is_thumbnail_loading(&path));
+        assert!(!app.active_thumbnail_requests.contains_key(&path));
+        assert!(app.pending_thumbnail_images.is_empty());
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,7 +7,7 @@
 pub mod components;
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use eframe::egui;
 
@@ -159,7 +159,8 @@ impl ElnPackApp {
                     request_id,
                     image,
                 } => {
-                    self.pending_thumbnail_images.push((path, request_id, image));
+                    self.pending_thumbnail_images
+                        .push((path, request_id, image));
                 }
                 mvu::Msg::Attachments(attachments::AttachmentsMsg::ThumbnailFailed {
                     path,
@@ -208,7 +209,7 @@ impl ElnPackApp {
                             .get(*index)
                             .map(|item| item.path.clone())
                         {
-                            self.invalidate_thumbnail_runtime_state(&path);
+                            self.invalidate_thumbnail_runtime_state(path.as_path());
                         }
                     }
                     let mut commands = Vec::new();
@@ -242,10 +243,9 @@ impl ElnPackApp {
                 egui::TextureOptions::default(),
             );
             self.thumbnail_textures.insert(path.clone(), texture);
-            self.inbox
-                .push(Msg::Attachments(attachments::AttachmentsMsg::ThumbnailAvailable {
-                    path,
-                }));
+            self.inbox.push(Msg::Attachments(
+                attachments::AttachmentsMsg::ThumbnailAvailable { path },
+            ));
         }
     }
 
@@ -265,7 +265,7 @@ impl ElnPackApp {
             .retain(|(path, _, _)| paths.contains(path));
     }
 
-    fn invalidate_thumbnail_runtime_state(&mut self, path: &PathBuf) {
+    fn invalidate_thumbnail_runtime_state(&mut self, path: &Path) {
         self.thumbnail_textures.remove(path);
         self.active_thumbnail_requests.remove(path);
         self.pending_thumbnail_images
@@ -274,26 +274,31 @@ impl ElnPackApp {
 
     fn dispatch_commands(&mut self, commands: Vec<Command>) {
         for cmd in commands {
-            let cmd = match cmd {
+            match cmd {
                 Command::LoadThumbnail {
                     path,
                     _retry,
                     request_id: _,
                 } => {
                     let request_id = self.next_thumbnail_request_id;
-                    self.next_thumbnail_request_id += 1;
-                    self.active_thumbnail_requests.insert(path.clone(), request_id);
-                    Command::LoadThumbnail {
+                    let tracked_path = path.clone();
+                    let cmd = Command::LoadThumbnail {
                         path,
                         _retry,
                         request_id,
+                    };
+                    if self.cmd_tx.send(cmd).is_ok() {
+                        self.next_thumbnail_request_id += 1;
+                        self.active_thumbnail_requests
+                            .insert(tracked_path, request_id);
+                        self.model.pending_commands += 1;
                     }
                 }
-                other => other,
-            };
-
-            if self.cmd_tx.send(cmd).is_ok() {
-                self.model.pending_commands += 1;
+                other => {
+                    if self.cmd_tx.send(other).is_ok() {
+                        self.model.pending_commands += 1;
+                    }
+                }
             }
         }
     }
@@ -570,7 +575,8 @@ mod tests {
             &mut Vec::new(),
         );
 
-        app.pending_thumbnail_images.push((path.clone(), 1, sample_image()));
+        app.pending_thumbnail_images
+            .push((path.clone(), 1, sample_image()));
 
         let ctx = egui::Context::default();
         app.realize_pending_thumbnail_textures(&ctx);
@@ -602,7 +608,7 @@ mod tests {
             Msg::Attachments(AttachmentsMsg::Remove(0)),
             &mut Vec::new(),
         );
-        app.invalidate_thumbnail_runtime_state(&path);
+        app.invalidate_thumbnail_runtime_state(path.as_path());
 
         assert!(app.model.attachments.add_path(path.clone()));
         let mut cmds = Vec::new();
@@ -648,7 +654,7 @@ mod tests {
             Msg::Attachments(AttachmentsMsg::Remove(0)),
             &mut Vec::new(),
         );
-        app.invalidate_thumbnail_runtime_state(&path);
+        app.invalidate_thumbnail_runtime_state(path.as_path());
 
         assert!(app.model.attachments.add_path(path.clone()));
         let mut cmds = Vec::new();
@@ -670,7 +676,10 @@ mod tests {
         app.process_runtime_messages();
 
         assert!(app.model.attachments.is_thumbnail_loading(&path));
-        assert_eq!(app.active_thumbnail_requests.get(&path), Some(&new_request_id));
+        assert_eq!(
+            app.active_thumbnail_requests.get(&path),
+            Some(&new_request_id)
+        );
     }
 
     #[test]
@@ -682,9 +691,10 @@ mod tests {
         let mut app = ElnPackApp::default();
         assert!(app.model.attachments.add_path(path.clone()));
 
-        app.inbox.push(Msg::Attachments(AttachmentsMsg::LoadThumbnail(
-            path.clone(),
-        )));
+        app.inbox
+            .push(Msg::Attachments(AttachmentsMsg::LoadThumbnail(
+                path.clone(),
+            )));
         app.inbox.push(Msg::Attachments(AttachmentsMsg::Remove(0)));
 
         app.process_runtime_messages();


### PR DESCRIPTION
## Summary
Move attachment thumbnail textures out of MVU state and into UI-owned runtime state.

## Why
The existing thumbnail flow stored egui runtime textures in attachment state and created textures during message processing, which mixed framework resources into the MVU layer.

## Impact
Thumbnail loading now stages decoded images in the runtime shell, realizes textures only in the UI path, and keeps attachment state limited to loading and failure tracking. The flow also ignores stale thumbnail results when attachments are removed and re-added at the same path.

## Validation
- cargo build
- cargo test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal thumbnail handling system with improved request tracking and validation.
  * Refactored message flow for thumbnail loading and caching to enhance reliability.

* **Chores**
  * Updated version control configuration to exclude local worktree directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->