### PR TITLE
fix: adapt UI to egui 0.35 API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ ehthumbs.db
 
 # SSH Keys
 id_ed25519*
+
+# tokensave
+.tokensave/

--- a/src/ui/components/attachments.rs
+++ b/src/ui/components/attachments.rs
@@ -755,7 +755,7 @@ mod tests {
         let ctx = egui::Context::default();
         let mut out = Vec::new();
         let _ = ctx.run_ui(Default::default(), |ui| {
-            egui::CentralPanel::default().show_inside(ui, |ui| {
+            egui::CentralPanel::default().show(ui, |ui| {
                 out = view(ui, &model, &HashMap::new());
             });
         });
@@ -776,7 +776,7 @@ mod tests {
         let mut out = Vec::new();
 
         let _ = ctx.run_ui(Default::default(), |ui| {
-            egui::CentralPanel::default().show_inside(ui, |ui| {
+            egui::CentralPanel::default().show(ui, |ui| {
                 out = view(ui, &model, &HashMap::new());
             });
         });
@@ -806,7 +806,7 @@ mod tests {
         );
 
         let _ = ctx.run_ui(Default::default(), |ui| {
-            egui::CentralPanel::default().show_inside(ui, |ui| {
+            egui::CentralPanel::default().show(ui, |ui| {
                 out = view(ui, &model, &textures);
             });
         });

--- a/src/ui/components/markdown.rs
+++ b/src/ui/components/markdown.rs
@@ -572,7 +572,7 @@ fn insert_table_at_cursor(model: &mut MarkdownModel, rows: u8, cols: u8) {
 fn selection(model: &MarkdownModel) -> (usize, usize, String) {
     let (start_char, end_char) = if let Some(range) = &model.cursor {
         let (a, b) = (range.primary.index, range.secondary.index);
-        (a.min(b), a.max(b))
+        (a.min(b).0, a.max(b).0)
     } else {
         let len = model.text.chars().count();
         (len, len)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -85,7 +85,7 @@ impl eframe::App for ElnPackApp {
         self.realize_pending_thumbnail_textures(ui.ctx());
         self.process_runtime_messages();
 
-        egui::Panel::top("top_bar").show_inside(ui, |ui| {
+        egui::Panel::top("top_bar").show(ui, |ui| {
             ui.add_space(6.0);
             ui.horizontal(|ui| {
                 ui.heading("ELN Entry");
@@ -106,11 +106,11 @@ impl eframe::App for ElnPackApp {
 
         egui::Panel::bottom("status_panel")
             .resizable(false)
-            .show_inside(ui, |ui| {
+            .show(ui, |ui| {
                 self.render_status(ui);
             });
 
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.add_space(8.0);
 
             egui::ScrollArea::vertical().show(ui, |ui| {


### PR DESCRIPTION
CI has been failing since egui was bumped 0.34→0.35 (#127, batch after 05f1794). egui 0.35 deprecated `show_inside` (renamed to `show`) and changed `CCursor::index` from `usize` to `CharIndex`.

- `src/ui/components/markdown.rs`: unwrap `CharIndex` to `usize` in `selection()`
- `src/ui/mod.rs`, `src/ui/components/attachments.rs`: replace deprecated `.show_inside(..)` with `.show(..)`

Verified: `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo test` 68 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text selection handling in Markdown content for more accurate cursor ranges.
  - Refined application panel layout rendering for more consistent UI behavior.
  - Improved attachment thumbnail loading behavior, including re-adding attachments and using cached or external textures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->